### PR TITLE
Trigger Maestro task when a PR merges to main

### DIFF
--- a/.github/workflows/trigger-maestro-task.yml
+++ b/.github/workflows/trigger-maestro-task.yml
@@ -1,0 +1,33 @@
+name: Trigger Maestro Task on Main Merge
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions: {}
+
+jobs:
+  trigger-task:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Trigger Maestro task template
+        env:
+          CC_PRSHARE_API_TOKEN: ${{ secrets.CC_PRSHARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          : "${CC_PRSHARE_API_TOKEN:?Set the CC_PRSHARE_API_TOKEN repository secret.}"
+
+          payload="$(jq -cn --rawfile event "$GITHUB_EVENT_PATH" '{context: {text: $event}}')"
+
+          curl --fail-with-body --silent --show-error \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --request POST 'https://cc.maestroerror.com/api/public/v1/task-templates/01KXP556K4A5T0JEWJBZZCQ71R/trigger' \
+            --header "Authorization: Bearer $CC_PRSHARE_API_TOKEN" \
+            --header 'Content-Type: application/json' \
+            --data "$payload"


### PR DESCRIPTION
## Summary

- add the Maestro task trigger workflow to Synapse
- trigger it when a pull request merges into `main`
- send the complete GitHub event payload to the same Maestro task-template endpoint used by `pest-plugin-evals`
- preserve the source workflow's authentication, timeout, permissions, and request behavior

## Verification

- `git diff --check origin/main...HEAD` passes
- manually compared the workflow with the source; only the display name and target branch changed from `4.x` to `main`
- `composer check` could not start because this checkout does not contain `vendor/bin/pint`

## Configuration

Configure `CC_PRSHARE_API_TOKEN` as a Synapse repository Actions secret before merging.