### PR TITLE
Prevent published migrations failing after --no-dev installs

### DIFF
--- a/.claude/skills/laravel-package/SKILL.md
+++ b/.claude/skills/laravel-package/SKILL.md
@@ -62,7 +62,7 @@ $this->publishes([__DIR__.'/../stubs/SynapseServiceProvider.stub' => app_path('P
 
 ## Migrations & models (Synapse conventions)
 
-- **Migrations** extend `Redberry\Synapse\Migrations\SynapseMigration`, whose `getConnection()` returns `config('synapse.storage.connection') ?: config('database.default')`.
+- **Published migrations are self-contained.** Each extends Laravel's `Migration` and implements `getConnection()` with `config('synapse.storage.connection') ?: config('database.default')`; never reference a Synapse class from a published migration because the file remains after `composer install --no-dev` removes the package.
 - **JSON is stored in `text` columns**, not `->json()` — sqlite has no native JSON type. Cast to `array` on the model.
 - **No DB foreign keys for cascade.** sqlite's FK pragma is off by default; cascade deletes live in `ConversationRepository`, not the schema.
 - **Models** extend `Redberry\Synapse\Models\SynapseModel`: `HasUuids` (this framework's `HasUuids` already yields uuid7 — the `HasVersion7Uuids` trait does not exist here), `$incrementing = false`, `$keyType = 'string'`, connection resolved from config. Use `const UPDATED_AT = null` when a table has only `created_at`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,11 @@ src/                          # PHP — the package
 ├── Synapse.php                       # static helpers: asset tags, script vars, auth callback
 ├── Http/{Controllers,Middleware}/    # HomeController (SPA shell), Authorize (viewSynapse gate)
 ├── Console/                          # Install / Prune / Clear commands
-├── Migrations/SynapseMigration.php   # connection resolver base
+├── Migrations/SynapseMigration.php   # legacy migration base retained for compatibility
 ├── Models/                           # SynapseModel base + Conversation/Message/ToolInvocation
 └── Repositories/                     # ConversationRepository (cascade delete lives here)
 config/synapse.php            # publishable config (enabled, ui, discovery, playground, storage, retention)
-database/migrations/          # the three synapse_* tables (publish-only)
+database/migrations/          # three self-contained synapse_* tables (publish-only)
 routes/web.php                # /api group (stubbed) + SPA catch-all
 resources/js/                 # React + TS SPA — elements/ → components/ → composed/ → pages/
                               #   (+ hooks, lib, types, styles)
@@ -56,7 +56,7 @@ Docs: [PRD.md](PRD.md), [GOAL.md](GOAL.md), [SCAFFOLDING.md](SCAFFOLDING.md), [D
 
 - **KISS** — don't over-engineer. Three similar lines beat a premature abstraction. No config options, flexibility, or helper indirection nobody asked for.
 - **DRY** — extract shared logic only once it appears in 2+ places with the same shape. Premature deduplication couples worse than duplication. (The `ConversationRepository` cascade earned extraction because prune, clear, and the future delete-endpoint all need it.)
-- **SOLID** — at package scale, the parts that matter: **single responsibility** (a controller doesn't build SQL; a command delegates to a repository/service), and **dependency inversion** (services/repositories receive collaborators via constructor injection so they're testable). Prefer composition over inheritance; the `SynapseModel`/`SynapseMigration` base classes are the deliberate exceptions (shared framework wiring).
+- **SOLID** — at package scale, the parts that matter: **single responsibility** (a controller doesn't build SQL; a command delegates to a repository/service), and **dependency inversion** (services/repositories receive collaborators via constructor injection so they're testable). Prefer composition over inheritance; `SynapseModel` is the deliberate exception for shared framework wiring.
 
 ## What NOT to do
 
@@ -260,7 +260,7 @@ PRD and GOAL move together — a behavior change usually touches both.
 |--------------|--------|
 | Add an API endpoint | `routes/web.php` (`/api` group, before the catch-all) + `src/Http/Controllers` |
 | Add business logic | a service in `src/` (e.g. `Discovery/`, `Recording/`) |
-| Add a DB table | `database/migrations/` (extend `SynapseMigration`) |
+| Add a DB table | `database/migrations/` (extend Laravel's `Migration` and keep the file independent of Synapse classes) |
 | Add a model | `src/Models/` (extend `SynapseModel`) |
 | Add a command | `src/Console/` + register in `SynapseServiceProvider` |
 | Add config | `config/synapse.php` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ version is below `1.0.0`, minor releases may contain breaking changes.
 
 ### Fixed
 
+- **Production migrations remain runnable after Synapse is removed.** Published migrations and the application provider no longer require package classes, while preserving `synapse.storage.connection`. Dev-mode package removal also unregisters the published provider automatically. Existing installations can force-republish migrations and update or unregister their old provider before deploying with `composer install --no-dev`.
 - **The dashboard reported the wrong version.** `Synapse::VERSION` was a hardcoded `0.1.0` that was not bumped for the `v0.1.1` release, so `php artisan about`, the sidebar footer and `window.Synapse.version` all claimed `0.1.0` on a `0.1.1` install. The version is now read from Composer's runtime metadata and cannot drift from what is installed; a test asserts the two agree.
 
 ### Changed

--- a/DEV.md
+++ b/DEV.md
@@ -92,7 +92,7 @@ Iterating on the package while the test app is running: because the package is *
 
 | Task | How |
 |------|-----|
-| Add a migration | Create `database/migrations/*_*.php` extending `SynapseMigration`; `text` columns for JSON; add a `defineDatabaseMigrations`-covered test. Migrations are publish-only — tests load them explicitly. |
+| Add a migration | Create a self-contained `database/migrations/*_*.php` extending Laravel's `Migration`; resolve `synapse.storage.connection` in the file, use `text` columns for JSON, and add a `defineDatabaseMigrations`-covered test. Migrations are publish-only and must remain loadable after Synapse is removed. |
 | Add a model | Extend `SynapseModel`; add `array` casts + `@property` docblocks; `const UPDATED_AT = null` if the table has only `created_at`. |
 | Add a command | Create in `src/Console`, register in `SynapseServiceProvider::registerCommands()`, add a Pest test asserting behavior. |
 | Add an API route | Add under the `/api` group in `routes/web.php` (before the catch-all); back it with a controller in `src/Http/Controllers`. |

--- a/GOAL.md
+++ b/GOAL.md
@@ -62,6 +62,15 @@ php artisan synapse:install
 - Runs Synapse's migrations
 - Publishes a `SynapseServiceProvider` into your app (where the access gate lives — see [Access control](#access-control--environments))
 
+The published migrations and provider do not require Synapse classes to load.
+Production can therefore remove the development dependency and still run all
+application migrations:
+
+```bash
+composer install --no-dev
+php artisan migrate --force
+```
+
 You never run `npm` — Synapse ships pre-built assets.
 
 **There is no asset publishing step, by design.** The compiled dashboard lives
@@ -81,6 +90,18 @@ That's it — new releases may add tables, and nothing else needs doing. Re-runn
 `php artisan synapse:install` is also safe: it never overwrites a
 `config/synapse.php` you have edited or a `SynapseServiceProvider` you have
 customised, so your access gate survives.
+
+**Upgrading an installation created by an older Synapse release:** refresh the
+old package-dependent migrations before removing development dependencies:
+
+```bash
+php artisan vendor:publish --tag=synapse-migrations --force
+```
+
+Update `app/Providers/SynapseServiceProvider.php` to match the current
+self-contained stub while preserving your gate, or remove its entry from
+`bootstrap/providers.php` before `composer install --no-dev`. Re-running
+`synapse:install` does not overwrite that customized provider automatically.
 
 Then open:
 

--- a/PRD.md
+++ b/PRD.md
@@ -674,7 +674,8 @@ Gate::define('viewSynapse', function ($user) {
 ```
 
 - **Production requires explicit opt-in.** In `production`, Synapse's routes do not register at all unless `SYNAPSE_ENABLED=true` is explicitly set — the existing `'enabled' => env('SYNAPSE_ENABLED', true)` config default applies to non-production environments only. Enabling it in production still requires passing the `viewSynapse` gate. Defense in depth: a forgotten `composer require` on a production box must not become an unauthenticated agent-invocation endpoint.
-- **`synapse:install` publishes the gate stub** so the definition lives in the app where developers can customize it, exactly like Telescope's install flow.
+- **`synapse:install` publishes the gate stub** so the definition lives in the app where developers can customize it, exactly like Telescope's install flow. The stub extends Laravel's `ServiceProvider` directly and only calls Synapse behind a `class_exists` guard, so it remains safe to bootstrap after `composer install --no-dev` removes the package.
+- **Package removal unregisters the published provider when Composer dispatches its dev-mode pre-uninstall event.** The self-contained stub remains the fallback for `--no-dev`, where Laravel intentionally does not dispatch package-uninstall events.
 
 ---
 
@@ -685,7 +686,7 @@ Gate::define('viewSynapse', function ($user) {
 Synapse follows the exact pattern proven by Telescope and used by `laravel/ai` itself: **migrations run against the user's database by default, with a configurable connection override.**
 
 - **Default:** tables are created on the app's default connection — the same approach as the SDK's own `AiMigration` (`config('ai.conversations.connection', config('database.default'))`).
-- **Override:** `SYNAPSE_DB_CONNECTION` points Synapse at any connection defined in `config/database.php`. Synapse's migration base class and all models resolve their connection from this config, mirroring `AiMigration::getConnection()`.
+- **Override:** `SYNAPSE_DB_CONNECTION` points Synapse at any connection defined in `config/database.php`. Each self-contained published migration and all models resolve their connection from this config, mirroring `AiMigration::getConnection()` without depending on package classes after publishing.
 - **Isolation recipe (documented in README):** users who want Synapse data fully out of their app database define a dedicated connection (e.g. a sqlite file) and set one env var:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ php artisan synapse:install
 
 That publishes `config/synapse.php`, runs the migrations, and installs a `SynapseServiceProvider` into your app — which is where the access gate lives. Then open `/synapse`.
 
+The published migrations and provider are self-contained, so production deployments may safely run `composer install --no-dev` followed by `php artisan migrate --force` after Composer removes Synapse.
+
+Upgrading from a release that published migrations extending `SynapseMigration` requires refreshing those files while Synapse is still installed:
+
+```bash
+php artisan vendor:publish --tag=synapse-migrations --force
+```
+
+Also update `app/Providers/SynapseServiceProvider.php` to extend `Illuminate\Support\ServiceProvider` and guard its `Redberry\Synapse\Synapse::auth(...)` call with `class_exists`, following the current published stub. Preserve your existing `viewSynapse` gate while doing so. Alternatively, remove that provider from `bootstrap/providers.php` before deploying without development dependencies.
+
 You never run `npm`. Compiled assets ship inside the package and are inlined into the dashboard, so there is no publish step and a `composer update` can never leave you on stale assets.
 
 Synapse reads your existing `config/ai.php`. You don't configure providers or API keys in Synapse; if your agents run in your app, they run here and vice versa.
@@ -86,7 +96,7 @@ Everything is optional; the defaults work.
 
 | Command | What it does |
 |---|---|
-| `synapse:install` | Publishes config, migrations and the gate provider, then migrates. Safe to re-run — it never overwrites your edits. |
+| `synapse:install` | Publishes self-contained config, migrations and the gate provider, then migrates. Safe to re-run — it never overwrites your edits. |
 | `synapse:prune` | Deletes conversations older than `--days`, with their attachments. |
 | `synapse:clear` | Deletes **all** Synapse conversations and attachments. |
 

--- a/SCAFFOLDING.md
+++ b/SCAFFOLDING.md
@@ -34,7 +34,7 @@ synapse/
 │   ├── Http/
 │   │   ├── Controllers/HomeController.php  # serves the SPA shell
 │   │   └── Middleware/Authorize.php        # viewSynapse gate check
-│   ├── Migrations/SynapseMigration.php     # connection resolver (mirrors AiMigration)
+│   ├── Migrations/SynapseMigration.php     # legacy connection resolver retained for compatibility
 │   ├── Models/
 │   │   ├── SynapseConversation.php
 │   │   ├── SynapseMessage.php
@@ -137,7 +137,7 @@ The exact config block from the PRD (`enabled`, `ui`, `discovery`, `playground.m
 - **`boot()`**:
   - `registerRoutes()` — guarded by the [Authorization](PRD.md#authorization--safety) rule: skip entirely in `production` unless `SYNAPSE_ENABLED=true`; wrap in `Route::group` with prefix `config('synapse.ui.path')` + configured middleware + the `Authorize` middleware.
   - `loadViewsFrom(resources/views, 'synapse')`.
-  - `registerPublishing()` — tags: `synapse-config`, `synapse-migrations` (`database/migrations` → app `database/migrations`, Telescope-style — **publish-only, not `loadMigrationsFrom`**), `synapse-provider` (stub → `app/Providers`). Migrations run when the app migrates after `synapse:install` publishes them.
+  - `registerPublishing()` — tags: `synapse-config`, `synapse-migrations` (`database/migrations` → app `database/migrations`, Telescope-style — **publish-only, not `loadMigrationsFrom`**), `synapse-provider` (stub → `app/Providers`). Published migrations are self-contained and run when the app migrates after `synapse:install` publishes them.
   - `registerCommands()`.
   - `registerAutoPrune()` — when `config('synapse.retention.auto_prune')`, `Schedule::command('synapse:prune --days=…')->daily()` (via `$this->callAfterResolving(Schedule::class, …)`).
   - `registerRecorder()` — subscribe `SynapseRecorder` to SDK events (wired now, no-op body until the recording phase).
@@ -149,7 +149,7 @@ Static helpers, mirroring `Horizon::css()/js()`:
 - `auth()` + `check()` — stores/evaluates the auth callback (local → open; else `Gate::check('viewSynapse')`), exactly like `Telescope::auth`.
 
 ### `src/SynapseApplicationServiceProvider.php` + `stubs/SynapseServiceProvider.stub`
-Base provider defines the `viewSynapse` gate + `Synapse::auth(...)` callback; the published stub extends it (Telescope's `TelescopeApplicationServiceProvider` pattern). `synapse:install` drops the stub into `app/Providers` and registers it in `bootstrap/providers.php`.
+The published provider extends Laravel's `ServiceProvider`, defines the `viewSynapse` gate, and registers the `Synapse::auth(...)` callback only while Synapse exists. `synapse:install` drops the stub into `app/Providers` and registers it in `bootstrap/providers.php`; a pre-uninstall listener removes that registration during dev-mode package removal.
 
 ### `src/Http/Middleware/Authorize.php`
 Calls `Synapse::check($request)`; aborts 403 otherwise.
@@ -204,11 +204,11 @@ The starting-point SPA renders the **real sidebar shell** (Recent Conversations 
 
 ## Phase 2 — Persistence
 
-### `src/Migrations/SynapseMigration.php`
-Abstract base overriding `getConnection()` → `config('synapse.storage.connection', config('database.default'))` (mirrors the SDK's `AiMigration`).
+### `src/Migrations/SynapseMigration.php` (legacy compatibility)
+The old connection-aware base remains available for compatibility, but published migrations do not extend it.
 
 ### `database/migrations/*_create_synapse_tables.php`
-The three tables exactly as specified in [PRD → Database Schema](PRD.md#database-schema): `synapse_conversations`, `synapse_messages`, `synapse_tool_invocations`. `text` columns for JSON; uuid7 string PKs; indexes as specified.
+The three self-contained migrations create the tables exactly as specified in [PRD → Database Schema](PRD.md#database-schema): `synapse_conversations`, `synapse_messages`, `synapse_tool_invocations`. Each resolves the configured connection without package classes. `text` columns for JSON; uuid7 string PKs; indexes as specified.
 
 ### `src/Models/*`
 - Connection-aware (`getConnectionName()` from config), `string` non-incrementing uuid7 keys.

--- a/database/migrations/2026_01_01_000001_create_synapse_conversations_table.php
+++ b/database/migrations/2026_01_01_000001_create_synapse_conversations_table.php
@@ -1,11 +1,16 @@
 <?php
 
+use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Redberry\Synapse\Migrations\SynapseMigration;
 
-return new class extends SynapseMigration
+return new class extends Migration
 {
+    public function getConnection(): ?string
+    {
+        return config('synapse.storage.connection') ?: config('database.default');
+    }
+
     public function up(): void
     {
         Schema::create('synapse_conversations', function (Blueprint $table) {

--- a/database/migrations/2026_01_01_000002_create_synapse_messages_table.php
+++ b/database/migrations/2026_01_01_000002_create_synapse_messages_table.php
@@ -1,11 +1,16 @@
 <?php
 
+use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Redberry\Synapse\Migrations\SynapseMigration;
 
-return new class extends SynapseMigration
+return new class extends Migration
 {
+    public function getConnection(): ?string
+    {
+        return config('synapse.storage.connection') ?: config('database.default');
+    }
+
     public function up(): void
     {
         Schema::create('synapse_messages', function (Blueprint $table) {

--- a/database/migrations/2026_01_01_000003_create_synapse_tool_invocations_table.php
+++ b/database/migrations/2026_01_01_000003_create_synapse_tool_invocations_table.php
@@ -1,11 +1,16 @@
 <?php
 
+use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use Redberry\Synapse\Migrations\SynapseMigration;
 
-return new class extends SynapseMigration
+return new class extends Migration
 {
+    public function getConnection(): ?string
+    {
+        return config('synapse.storage.connection') ?: config('database.default');
+    }
+
     public function up(): void
     {
         Schema::create('synapse_tool_invocations', function (Blueprint $table) {

--- a/src/SynapseServiceProvider.php
+++ b/src/SynapseServiceProvider.php
@@ -27,6 +27,8 @@ class SynapseServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $this->registerPrePackageUninstallListener();
+
         $this->registerRoutes();
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'synapse');
@@ -38,6 +40,16 @@ class SynapseServiceProvider extends ServiceProvider
             $this->registerCommands();
             $this->registerAboutCommand();
         }
+    }
+
+    /**
+     * Remove the published provider from the host application before uninstalling.
+     */
+    protected function registerPrePackageUninstallListener(): void
+    {
+        $this->app['events']->listen('composer_package.redberry/synapse:pre_uninstall', function (): void {
+            ServiceProvider::removeProviderFromBootstrapFile('App\\Providers\\SynapseServiceProvider', strict: true);
+        });
     }
 
     /**

--- a/stubs/SynapseServiceProvider.stub
+++ b/stubs/SynapseServiceProvider.stub
@@ -3,21 +3,25 @@
 namespace App\Providers;
 
 use Illuminate\Support\Facades\Gate;
-use Redberry\Synapse\SynapseApplicationServiceProvider;
+use Illuminate\Support\ServiceProvider;
 
-class SynapseServiceProvider extends SynapseApplicationServiceProvider
+class SynapseServiceProvider extends ServiceProvider
 {
     /**
-     * Register the Synapse gate.
-     *
-     * This gate determines who can access Synapse in non-local environments.
+     * Bootstrap any application services.
      */
-    protected function gate(): void
+    public function boot(): void
     {
         Gate::define('viewSynapse', function ($user) {
             return in_array($user->email, [
                 //
             ]);
         });
+
+        if (class_exists(\Redberry\Synapse\Synapse::class)) {
+            \Redberry\Synapse\Synapse::auth(function ($request) {
+                return Gate::check('viewSynapse', [$request->user()]);
+            });
+        }
     }
 }

--- a/stubs/SynapseServiceProvider.stub
+++ b/stubs/SynapseServiceProvider.stub
@@ -13,14 +13,14 @@ class SynapseServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Gate::define('viewSynapse', function ($user) {
-            return in_array($user->email, [
+            return in_array($user?->email, [
                 //
             ]);
         });
 
         if (class_exists(\Redberry\Synapse\Synapse::class)) {
             \Redberry\Synapse\Synapse::auth(function ($request) {
-                return Gate::check('viewSynapse', [$request->user()]);
+                return Gate::forUser($request->user())->check('viewSynapse');
             });
         }
     }

--- a/tests/Feature/InstallTest.php
+++ b/tests/Feature/InstallTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Redberry\Synapse\Synapse;
 
@@ -112,6 +113,45 @@ it('registers the provider once however many times it is run', function () {
     fn (): bool => ! file_exists(base_path('bootstrap/providers.php')),
     'The skeleton has no bootstrap/providers.php to register into.',
 );
+
+it('removes the published provider registration before uninstalling', function () {
+    $this->artisan('synapse:install', ['--no-migrate' => true])->assertSuccessful();
+
+    Event::dispatch('composer_package.redberry/synapse:pre_uninstall');
+
+    expect(File::get(base_path('bootstrap/providers.php')))
+        ->not->toContain('App\\Providers\\SynapseServiceProvider');
+})->skip(
+    fn (): bool => ! file_exists(base_path('bootstrap/providers.php')),
+    'The skeleton has no bootstrap/providers.php to unregister from.',
+);
+
+it('publishes resources that remain loadable without Synapse classes', function () {
+    $this->artisan('synapse:install', ['--no-migrate' => true])->assertSuccessful();
+
+    $migrationFiles = File::files(database_path('migrations'));
+    $publishedProvider = File::get(app_path('Providers/SynapseServiceProvider.php'));
+
+    expect($migrationFiles)->toHaveCount(3)
+        ->and($publishedProvider)->toContain('extends ServiceProvider')
+        ->and($publishedProvider)->not->toContain('extends SynapseApplicationServiceProvider');
+
+    foreach ($migrationFiles as $migrationFile) {
+        expect($migrationFile->getContents())
+            ->toContain('extends Migration')
+            ->not->toContain('Redberry\\Synapse\\Migrations');
+    }
+});
+
+it('keeps the configured connection in self-contained migrations', function () {
+    config()->set('synapse.storage.connection', 'synapse-testing');
+
+    foreach (File::files(dirname(__DIR__, 2).'/database/migrations') as $migrationFile) {
+        $migration = require $migrationFile->getPathname();
+
+        expect($migration->getConnection())->toBe('synapse-testing');
+    }
+});
 
 it('reports itself in php artisan about', function () {
     $about = synapseAbout();

--- a/tests/Feature/InstallTest.php
+++ b/tests/Feature/InstallTest.php
@@ -134,7 +134,9 @@ it('publishes resources that remain loadable without Synapse classes', function 
 
     expect($migrationFiles)->toHaveCount(3)
         ->and($publishedProvider)->toContain('extends ServiceProvider')
-        ->and($publishedProvider)->not->toContain('extends SynapseApplicationServiceProvider');
+        ->and($publishedProvider)->not->toContain('extends SynapseApplicationServiceProvider')
+        ->and($publishedProvider)->toContain('in_array($user?->email')
+        ->and($publishedProvider)->toContain("Gate::forUser(\$request->user())->check('viewSynapse')");
 
     foreach ($migrationFiles as $migrationFile) {
         expect($migrationFile->getContents())


### PR DESCRIPTION
## Summary

- make all three published migrations self-contained while preserving `synapse.storage.connection`
- publish a self-contained application provider and unregister it during dev-mode package removal
- document the existing-installation migration/provider upgrade path
- add regression coverage for package-independent resources, configured connections, and provider cleanup

## Verification

- `./vendor/bin/pest tests/Feature/InstallTest.php tests/Feature/ModelTest.php` (10 passed, 47 assertions)
- `composer check` (Pint passed, PHPStan no errors, 198 tests passed with 523 assertions)
- Real Laravel 13 host smoke: require Synapse as a dev dependency, run `php artisan synapse:install`, run `composer install --no-dev`, then `php artisan migrate:fresh --force`; all app and Synapse migrations completed with the package absent

Closes #10