### PR TITLE
Prevent dev-only provider registration breaking production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ version is below `1.0.0`, minor releases may contain breaking changes.
 
 ### Fixed
 
+- **Dev-only installs no longer break production boot.** `synapse:install` now registers the published application provider only in `local` and only while Synapse's package classes exist. It also removes the old unconditional `bootstrap/providers.php` entry, so applications continue to boot after `composer install --no-dev`; repeat installs remain idempotent and preserve application edits.
 - **The dashboard reported the wrong version.** `Synapse::VERSION` was a hardcoded `0.1.0` that was not bumped for the `v0.1.1` release, so `php artisan about`, the sidebar footer and `window.Synapse.version` all claimed `0.1.0` on a `0.1.1` install. The version is now read from Composer's runtime metadata and cannot drift from what is installed; a test asserts the two agree.
 
 ### Changed

--- a/GOAL.md
+++ b/GOAL.md
@@ -61,6 +61,7 @@ php artisan synapse:install
 - Publishes `config/synapse.php`
 - Runs Synapse's migrations
 - Publishes a `SynapseServiceProvider` into your app (where the access gate lives — see [Access control](#access-control--environments))
+- Adds an idempotent registration to `AppServiceProvider` that loads the published provider only in `local` and only while the Synapse package exists
 
 You never run `npm` — Synapse ships pre-built assets.
 
@@ -70,6 +71,19 @@ copied into your `public/` directory, so a `composer update` can never leave you
 running last month's JavaScript against this month's API — the usual way a
 dashboard package breaks after an upgrade. There is nothing to re-publish and no
 cache to bust.
+
+**For production deployments:**
+
+```bash
+composer install --no-dev
+```
+
+No manual provider removal is needed. The local registration checks that the
+Synapse package class exists, so Laravel still boots after Composer removes the
+development dependency. Existing installations that contain
+`App\Providers\SynapseServiceProvider` in `bootstrap/providers.php` should run
+`php artisan synapse:install` once locally before deployment; the command moves
+registration to `AppServiceProvider` without overwriting the customized gate.
 
 **After a `composer update`:**
 
@@ -356,7 +370,7 @@ return [
 Synapse invokes your **real agents** — spending API credits and running tools that may write to your database, call external services, or trigger any side effect your tools implement. So access is guarded accordingly.
 
 - **Local:** open, no authentication. Zero-config dev experience.
-- **Any other environment:** every route (dashboard and API) is protected by a `viewSynapse` authorization gate. `synapse:install` publishes this gate into your app so you own it:
+- **Any other environment:** the standard `--dev` installation does not register the published provider. If you deliberately adapt the installation for another environment, every route (dashboard and API) is protected by the published `viewSynapse` authorization gate:
 
   ```php
   // app/Providers/SynapseServiceProvider.php
@@ -367,7 +381,7 @@ Synapse invokes your **real agents** — spending API credits and running tools 
   });
   ```
 
-- **Production:** Synapse does **not** register at all unless `SYNAPSE_ENABLED=true` is explicitly set — and even then, access still requires passing the `viewSynapse` gate. A forgotten `composer require` on a production box can never become an open agent-invocation endpoint.
+- **Production:** the supported flow removes Synapse with `composer install --no-dev`; the guarded application registration remains safe when its package classes are absent. If Synapse is installed deliberately, it still does **not** register routes unless `SYNAPSE_ENABLED=true` is explicitly set, and access requires a configured `viewSynapse` gate.
 
 Synapse is a development tool. Running it in production is possible but deliberately locked down.
 

--- a/PRD.md
+++ b/PRD.md
@@ -674,7 +674,8 @@ Gate::define('viewSynapse', function ($user) {
 ```
 
 - **Production requires explicit opt-in.** In `production`, Synapse's routes do not register at all unless `SYNAPSE_ENABLED=true` is explicitly set — the existing `'enabled' => env('SYNAPSE_ENABLED', true)` config default applies to non-production environments only. Enabling it in production still requires passing the `viewSynapse` gate. Defense in depth: a forgotten `composer require` on a production box must not become an unauthenticated agent-invocation endpoint.
-- **`synapse:install` publishes the gate stub** so the definition lives in the app where developers can customize it, exactly like Telescope's install flow.
+- **`synapse:install` publishes the gate stub** so the definition lives in the app where developers can customize it. It registers that provider from `AppServiceProvider` only when the application is `local` and `SynapseApplicationServiceProvider` exists. This keeps the `--dev` installation local while allowing production to boot after `composer install --no-dev` removes the package.
+- **Installer registration is idempotent and migrates old installs.** Re-running the command preserves host application edits, never duplicates the guarded block, and removes the old unconditional `bootstrap/providers.php` entry.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ composer require redberry/synapse --dev
 php artisan synapse:install
 ```
 
-That publishes `config/synapse.php`, runs the migrations, and installs a `SynapseServiceProvider` into your app — which is where the access gate lives. Then open `/synapse`.
+That publishes `config/synapse.php`, runs the migrations, and publishes a `SynapseServiceProvider` into your app — which is where the access gate lives. The installer conditionally registers that provider from `AppServiceProvider` only in `local` and while the Synapse package is installed. Then open `/synapse`.
+
+For production, install dependencies without development packages as usual:
+
+```bash
+composer install --no-dev
+```
+
+No provider cleanup is required. Synapse is omitted, and the generated `class_exists` guard lets the application boot without it. If an older Synapse install added `App\Providers\SynapseServiceProvider` to `bootstrap/providers.php`, re-run `php artisan synapse:install` locally once before deploying; the installer removes that stale entry without overwriting your gate.
 
 You never run `npm`. Compiled assets ship inside the package and are inlined into the dashboard, so there is no publish step and a `composer update` can never leave you on stale assets.
 
@@ -43,7 +51,7 @@ Synapse reads your existing `config/ai.php`. You don't configure providers or AP
 Two independent protections, both on by default:
 
 1. **It does not register at all in production** unless you explicitly set `SYNAPSE_ENABLED=true`.
-2. **Outside `local`, every route — dashboard and API — passes the `viewSynapse` gate**, which denies everyone until you say otherwise:
+2. **The supported `--dev` installation registers the dashboard only in `local`.** The published provider owns the `viewSynapse` gate if you adapt the installation for another environment:
 
    ```php
    // app/Providers/SynapseServiceProvider.php
@@ -86,7 +94,7 @@ Everything is optional; the defaults work.
 
 | Command | What it does |
 |---|---|
-| `synapse:install` | Publishes config, migrations and the gate provider, then migrates. Safe to re-run — it never overwrites your edits. |
+| `synapse:install` | Publishes config, migrations and the gate provider, registers it locally from `AppServiceProvider`, then migrates. Safe to re-run — it never overwrites your edits. |
 | `synapse:prune` | Deletes conversations older than `--days`, with their attachments. |
 | `synapse:clear` | Deletes **all** Synapse conversations and attachments. |
 

--- a/SCAFFOLDING.md
+++ b/SCAFFOLDING.md
@@ -149,7 +149,7 @@ Static helpers, mirroring `Horizon::css()/js()`:
 - `auth()` + `check()` — stores/evaluates the auth callback (local → open; else `Gate::check('viewSynapse')`), exactly like `Telescope::auth`.
 
 ### `src/SynapseApplicationServiceProvider.php` + `stubs/SynapseServiceProvider.stub`
-Base provider defines the `viewSynapse` gate + `Synapse::auth(...)` callback; the published stub extends it (Telescope's `TelescopeApplicationServiceProvider` pattern). `synapse:install` drops the stub into `app/Providers` and registers it in `bootstrap/providers.php`.
+Base provider defines the `viewSynapse` gate + `Synapse::auth(...)` callback; the published stub extends it (Telescope's `TelescopeApplicationServiceProvider` pattern). `synapse:install` drops the stub into `app/Providers` and conditionally registers it from `AppServiceProvider` only in `local` while the package exists.
 
 ### `src/Http/Middleware/Authorize.php`
 Calls `Synapse::check($request)`; aborts 403 otherwise.
@@ -220,7 +220,7 @@ The three tables exactly as specified in [PRD → Database Schema](PRD.md#databa
 ## Phase 3 — Install command, workbench & first green test
 
 ### `src/Console/InstallCommand.php` (`synapse:install`)
-`vendor:publish` for `synapse-config`, `synapse-migrations`, `synapse-provider`; register the app provider in `bootstrap/providers.php` (`ServiceProvider::addProviderToBootstrapFile`); run `migrate`. (Telescope's `InstallCommand` is the template.)
+`vendor:publish` for `synapse-config`, `synapse-migrations`, `synapse-provider`; add an idempotent local-only, class-guarded registration to `AppServiceProvider`; remove legacy unconditional registration from `bootstrap/providers.php`; run `migrate`.
 
 ### `src/Console/PruneCommand.php` (`synapse:prune`)
 `--days=` option (default `config('synapse.retention.days')`); deletes conversations older than the threshold on `updated_at`, cascading messages + tool rows + attachment files through the repository.
@@ -286,7 +286,7 @@ composer test           # Pest against workbench
 - [x] `composer test` green — **8 passed (24 assertions)**: dashboard 200/403, commands registered, tables + uuid7 + casts, prune/clear + cascade
 - [x] In `testing-laravel-project/`: `composer require redberry/synapse:@dev` → `php artisan synapse:install` → visiting `/synapse` renders the React sidebar shell with the empty Discovery page (screenshot-verified)
 - [x] `synapse:prune` / `synapse:clear` covered by passing tests
-- [x] `viewSynapse` gate stub published to `app/Providers`; provider registered in `bootstrap/providers.php`; production route guard is config-cache safe
+- [x] `viewSynapse` gate stub published to `app/Providers`; provider registered locally and conditionally from `AppServiceProvider`; production route guard is config-cache safe
 
 ---
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -38,32 +38,39 @@ class InstallCommand extends Command
     protected function registerSynapseServiceProvider(): void
     {
         $path = app_path('Providers/AppServiceProvider.php');
+
+        if (! File::exists($path)) {
+            throw new RuntimeException(
+                'Unable to register Synapse: app/Providers/AppServiceProvider.php was not found. Recreate it or register SynapseServiceProvider manually.'
+            );
+        }
+
         $contents = File::get($path);
 
         if (! str_contains($contents, '$this->app->register(SynapseServiceProvider::class)')) {
             $eol = str_contains($contents, "\r\n") ? "\r\n" : "\n";
-            $registerMethod = "    public function register(): void{$eol}    {{$eol}";
 
-            if (! str_contains($contents, $registerMethod)) {
+            $updatedContents = preg_replace(
+                '/^(\s*public\s+function\s+register\s*\(\s*\)\s*(?::\s*void)?\s*(?:\{\R|\R\s*\{\R))/m',
+                '$1'.implode($eol, [
+                    "        if (\$this->app->environment('local') &&",
+                    '            class_exists(\\Redberry\\Synapse\\SynapseApplicationServiceProvider::class)) {',
+                    '            $this->app->register(SynapseServiceProvider::class);',
+                    '        }',
+                    '',
+                    '',
+                ]),
+                $contents,
+                1,
+            );
+
+            if ($updatedContents === null || $updatedContents === $contents) {
                 throw new RuntimeException(
                     'Unable to register Synapse: App\\Providers\\AppServiceProvider::register() was not found.'
                 );
             }
 
-            $registration = implode($eol, [
-                "        if (\$this->app->environment('local') &&",
-                '            class_exists(\\Redberry\\Synapse\\SynapseApplicationServiceProvider::class)) {',
-                '            $this->app->register(SynapseServiceProvider::class);',
-                '        }',
-                '',
-                '',
-            ]);
-
-            File::put($path, str_replace(
-                $registerMethod,
-                $registerMethod.$registration,
-                $contents,
-            ));
+            File::put($path, $updatedContents);
         }
 
         ServiceProvider::removeProviderFromBootstrapFile(

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -3,7 +3,9 @@
 namespace Redberry\Synapse\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
+use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'synapse:install')]
@@ -33,11 +35,40 @@ class InstallCommand extends Command
         return self::SUCCESS;
     }
 
-    /**
-     * Register the published SynapseServiceProvider in the application.
-     */
     protected function registerSynapseServiceProvider(): void
     {
-        ServiceProvider::addProviderToBootstrapFile('App\\Providers\\SynapseServiceProvider');
+        $path = app_path('Providers/AppServiceProvider.php');
+        $contents = File::get($path);
+
+        if (! str_contains($contents, '$this->app->register(SynapseServiceProvider::class)')) {
+            $eol = str_contains($contents, "\r\n") ? "\r\n" : "\n";
+            $registerMethod = "    public function register(): void{$eol}    {{$eol}";
+
+            if (! str_contains($contents, $registerMethod)) {
+                throw new RuntimeException(
+                    'Unable to register Synapse: App\\Providers\\AppServiceProvider::register() was not found.'
+                );
+            }
+
+            $registration = implode($eol, [
+                "        if (\$this->app->environment('local') &&",
+                '            class_exists(\\Redberry\\Synapse\\SynapseApplicationServiceProvider::class)) {',
+                '            $this->app->register(SynapseServiceProvider::class);',
+                '        }',
+                '',
+                '',
+            ]);
+
+            File::put($path, str_replace(
+                $registerMethod,
+                $registerMethod.$registration,
+                $contents,
+            ));
+        }
+
+        ServiceProvider::removeProviderFromBootstrapFile(
+            'App\\Providers\\SynapseServiceProvider',
+            strict: true,
+        );
     }
 }

--- a/tests/Feature/InstallTest.php
+++ b/tests/Feature/InstallTest.php
@@ -2,7 +2,9 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\ServiceProvider;
 use Redberry\Synapse\Synapse;
+use Symfony\Component\Process\Process;
 
 /*
 | `synapse:install` must be safe to run twice.
@@ -22,15 +24,14 @@ use Redberry\Synapse\Synapse;
  * a customised file already in place and the idempotency assertion would pass
  * without ever publishing anything.
  *
- * The bootstrap entry is worse than stale: `addProviderToBootstrapFile()`
- * registers `App\Providers\SynapseServiceProvider` permanently, while the class
- * file itself is deleted here — leaving the skeleton pointing at a class that
- * does not exist, for every other test in the repository.
+ * The bootstrap cleanup also isolates the legacy-registration migration test
+ * from every other test in the repository.
  */
 function forgetPublishedFiles(): void
 {
     File::delete([
         config_path('synapse.php'),
+        app_path('Providers/AppServiceProvider.php'),
         app_path('Providers/SynapseServiceProvider.php'),
     ]);
 
@@ -43,6 +44,33 @@ function forgetPublishedFiles(): void
             File::get($bootstrap),
         ));
     }
+}
+
+function createApplicationProvider(): void
+{
+    $provider = app_path('Providers/AppServiceProvider.php');
+
+    File::ensureDirectoryExists(dirname($provider));
+    File::put($provider, <<<'PHP'
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        //
+    }
+
+    public function boot(): void
+    {
+        //
+    }
+}
+PHP);
 }
 
 /**
@@ -66,7 +94,10 @@ function synapseAbout(): array
     return json_decode(Artisan::output(), true)['synapse'] ?? [];
 }
 
-beforeEach(fn () => forgetPublishedFiles());
+beforeEach(function () {
+    forgetPublishedFiles();
+    createApplicationProvider();
+});
 afterEach(fn () => forgetPublishedFiles());
 
 it('does not overwrite a customised config or an edited provider', function () {
@@ -99,19 +130,73 @@ it('does not overwrite a customised config or an edited provider', function () {
         ->and(File::get($provider))->toContain('ada@example.com');
 });
 
-it('registers the provider once however many times it is run', function () {
-    $this->artisan('synapse:install', ['--no-migrate' => true])->assertSuccessful();
+it('registers the provider locally once however many times it is run', function () {
     $this->artisan('synapse:install', ['--no-migrate' => true])->assertSuccessful();
 
-    $bootstrap = base_path('bootstrap/providers.php');
+    $path = app_path('Providers/AppServiceProvider.php');
+    File::put($path, str_replace('//', '// Keep this application binding.', File::get($path)));
 
-    expect(substr_count(File::get($bootstrap), 'App\\Providers\\SynapseServiceProvider'))->toBe(1);
-})->skip(
-    // A closure, because `base_path()` needs a booted app and a bare argument
-    // is evaluated while the file is still being collected.
-    fn (): bool => ! file_exists(base_path('bootstrap/providers.php')),
-    'The skeleton has no bootstrap/providers.php to register into.',
-);
+    $this->artisan('synapse:install', ['--no-migrate' => true])->assertSuccessful();
+
+    $appServiceProvider = File::get($path);
+
+    expect(substr_count($appServiceProvider, "environment('local')"))->toBe(1)
+        ->and(substr_count($appServiceProvider, 'SynapseApplicationServiceProvider::class'))->toBe(1)
+        ->and(substr_count($appServiceProvider, '$this->app->register(SynapseServiceProvider::class)'))->toBe(1)
+        ->and($appServiceProvider)->toContain('// Keep this application binding.')
+        ->and(File::get(base_path('bootstrap/providers.php')))
+        ->not->toContain('App\\Providers\\SynapseServiceProvider');
+});
+
+it('removes the old unconditional provider registration', function () {
+    ServiceProvider::addProviderToBootstrapFile('App\\Providers\\SynapseServiceProvider');
+
+    $this->artisan('synapse:install', ['--no-migrate' => true])->assertSuccessful();
+
+    expect(File::get(base_path('bootstrap/providers.php')))
+        ->not->toContain('App\\Providers\\SynapseServiceProvider');
+});
+
+it('boots the generated application provider without Synapse installed', function () {
+    $this->artisan('synapse:install', ['--no-migrate' => true])->assertSuccessful();
+
+    expect(File::get(app_path('Providers/AppServiceProvider.php')))
+        ->toContain('class_exists(\\Redberry\\Synapse\\SynapseApplicationServiceProvider::class)');
+
+    $provider = var_export(app_path('Providers/AppServiceProvider.php'), true);
+    $script = <<<PHP
+namespace Illuminate\Support {
+    class ServiceProvider {
+        public function __construct(protected object \$app) {}
+    }
+}
+
+namespace {
+    require {$provider};
+
+    \$app = new class {
+        public function environment(string \$environment): bool
+        {
+            return \$environment === 'local';
+        }
+
+        public function register(string \$provider): void
+        {
+            throw new RuntimeException("Unexpected provider registration: {\$provider}");
+        }
+    };
+
+    (new App\Providers\AppServiceProvider(\$app))->register();
+    echo 'booted';
+}
+PHP;
+    $process = new Process([PHP_BINARY, '-r', $script]);
+    $process->run();
+
+    expect($process->isSuccessful())->toBeTrue()
+        ->and($process->getOutput())->toBe('booted')
+        ->and($process->getErrorOutput())->toBeEmpty();
+});
 
 it('reports itself in php artisan about', function () {
     $about = synapseAbout();

--- a/tests/Feature/InstallTest.php
+++ b/tests/Feature/InstallTest.php
@@ -31,7 +31,6 @@ function forgetPublishedFiles(): void
 {
     File::delete([
         config_path('synapse.php'),
-        app_path('Providers/AppServiceProvider.php'),
         app_path('Providers/SynapseServiceProvider.php'),
     ]);
 
@@ -46,12 +45,12 @@ function forgetPublishedFiles(): void
     }
 }
 
-function createApplicationProvider(): void
+function createApplicationProvider(?string $contents = null): void
 {
     $provider = app_path('Providers/AppServiceProvider.php');
 
     File::ensureDirectoryExists(dirname($provider));
-    File::put($provider, <<<'PHP'
+    File::put($provider, $contents ?? <<<'PHP'
 <?php
 
 namespace App\Providers;
@@ -146,6 +145,40 @@ it('registers the provider locally once however many times it is run', function 
         ->and($appServiceProvider)->toContain('// Keep this application binding.')
         ->and(File::get(base_path('bootstrap/providers.php')))
         ->not->toContain('App\\Providers\\SynapseServiceProvider');
+});
+
+it('fails clearly when the application provider file is missing', function () {
+    File::delete(app_path('Providers/AppServiceProvider.php'));
+
+    expect(fn () => $this->artisan('synapse:install', ['--no-migrate' => true]))
+        ->toThrow(RuntimeException::class, 'Unable to register Synapse: app/Providers/AppServiceProvider.php was not found.');
+});
+
+it('registers the provider when the host app uses a valid register signature variant', function () {
+    createApplicationProvider(<<<'PHP'
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function register() {
+        //
+    }
+
+    public function boot(): void
+    {
+        //
+    }
+}
+PHP);
+
+    $this->artisan('synapse:install', ['--no-migrate' => true])->assertSuccessful();
+
+    expect(File::get(app_path('Providers/AppServiceProvider.php')))
+        ->toContain('$this->app->register(SynapseServiceProvider::class)');
 });
 
 it('removes the old unconditional provider registration', function () {


### PR DESCRIPTION
## Summary

- register the published Synapse application provider from `AppServiceProvider` only in `local` and only while package classes exist
- remove legacy unconditional registration from `bootstrap/providers.php` while preserving repeat-install and host edits
- add an isolated no-package boot regression test and synchronize installation/deployment documentation

## Verification

- `./vendor/bin/pest tests/Feature/InstallTest.php` (7 passed, 34 assertions)
- `composer check` (Pint passed, PHPStan no errors, 197 tests passed with 519 assertions)
- `git diff --check origin/main...HEAD`

Closes #9